### PR TITLE
fix : implement the improvements to the QA for project-related APIs

### DIFF
--- a/src/main/java/com/prismworks/prism/domain/project/Repository/ProjectRepository.java
+++ b/src/main/java/com/prismworks/prism/domain/project/Repository/ProjectRepository.java
@@ -8,8 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface ProjectRepository extends JpaRepository<Project, Integer>, ProjectCustomRepository {
-    @Query("SELECT p FROM Project p WHERE p.projectName = :projectName AND p.visibility = true")
-    List<Project> findByName(String projectName);
+    @Query("SELECT p FROM Project p WHERE p.projectName = :projectName AND p.visibility = true AND p.createdBy = :userEmail")
+    List<Project> findByProjectNameAndUserEmail(String projectName,String userEmail);
 
     @Query("SELECT DISTINCT p FROM Project p LEFT JOIN p.members m LEFT JOIN p.categories c WHERE " +
             "(:projectName IS NULL OR p.projectName = :projectName) OR " +
@@ -23,4 +23,5 @@ public interface ProjectRepository extends JpaRepository<Project, Integer>, Proj
 
     @Query("SELECT p FROM Project p WHERE p.createdBy = :email")
     List<Project> findByOwnerEmail(String email);
+
 }

--- a/src/main/java/com/prismworks/prism/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/prismworks/prism/domain/project/controller/ProjectController.java
@@ -52,10 +52,12 @@ public class ProjectController {
 
     //테스트 완료
     @GetMapping("/summary/by-name")
-    public ApiSuccessResponse getProjectSummaryByName(@RequestParam String projectName) {
-        List<SummaryProjectDto> summaryProjects = projectService.getProjectSummaryByName(projectName);
+    public ApiSuccessResponse getProjectSummaryByName(@CurrentUser UserContext userContext,
+                                                      @RequestParam String projectName) {
+        List<SummaryProjectDto> summaryProjects = projectService.getProjectSummaryByName(userContext.getEmail(), projectName);
         return new ApiSuccessResponse(HttpStatus.OK.value(), summaryProjects);
     }
+
 
     @GetMapping("/summary/by-member-and-filters")
     public ApiSuccessResponse getProjectSummaryByMemberAndFilters(

--- a/src/main/java/com/prismworks/prism/domain/project/dto/MemberDto.java
+++ b/src/main/java/com/prismworks/prism/domain/project/dto/MemberDto.java
@@ -15,5 +15,4 @@ public class MemberDto {
     private String email;
     @NotEmpty
     private List<String> roles;
-    //private List<String> skills;
 }

--- a/src/main/java/com/prismworks/prism/domain/project/dto/ProjectDetailDto.java
+++ b/src/main/java/com/prismworks/prism/domain/project/dto/ProjectDetailDto.java
@@ -13,6 +13,7 @@ public class ProjectDetailDto {
     private String startDate;
     private String endDate;
     private String projectUrlLink;
+    private boolean visibility;
     private String projectDescription;
     private List<String> categories;
     private List<String> skills;

--- a/src/main/java/com/prismworks/prism/domain/project/dto/ProjectDto.java
+++ b/src/main/java/com/prismworks/prism/domain/project/dto/ProjectDto.java
@@ -17,13 +17,13 @@ public class ProjectDto {
     private String organizationName;
     private int memberCount;
     private List<String> categories;
-    //private List<String> hashTags;
     private List<String> skills;
     @NotEmpty
     private String startDate;
     @NotEmpty
     private String endDate;
     private String projectUrlLink;
+    private boolean visibility;
     @NotEmpty
     private String createdBy; // 프로젝트 소유자 이메일 추가
     @NotEmpty

--- a/src/main/java/com/prismworks/prism/domain/project/dto/ProjectResponseDto.java
+++ b/src/main/java/com/prismworks/prism/domain/project/dto/ProjectResponseDto.java
@@ -1,6 +1,5 @@
 package com.prismworks.prism.domain.project.dto;
 
-import com.prismworks.prism.domain.project.model.Category;
 import com.prismworks.prism.domain.project.model.ProjectCategoryJoin;
 import lombok.Builder;
 import lombok.Data;
@@ -18,10 +17,10 @@ public class ProjectResponseDto {
     private String organizationName;
     private int memberCount;
     private Set<ProjectCategoryJoin> categories;
-    //private List<String> hashTags;
     private List<String> skills;
     private Date startDate;
     private Date endDate;
     private String projectUrlLink;
+    private boolean visibility;
     private String createdBy; // 프로젝트 소유자 이메일 추가
 }

--- a/src/main/java/com/prismworks/prism/domain/project/model/ProjectUserJoin.java
+++ b/src/main/java/com/prismworks/prism/domain/project/model/ProjectUserJoin.java
@@ -25,12 +25,6 @@ public class ProjectUserJoin {
 
     private String name;
     private String email;
-    /*
-    @ElementCollection
-    @CollectionTable(name = "project_user_skills", joinColumns = @JoinColumn(name = "project_user_joins_id"))
-    @Column(name = "skill")
-    private List<String> skills;
-    */
     @ElementCollection
     @CollectionTable(name = "project_user_roles", joinColumns = @JoinColumn(name = "project_user_joins_id"))
     @Column(name = "role")

--- a/src/main/java/com/prismworks/prism/domain/project/service/ProjectService.java
+++ b/src/main/java/com/prismworks/prism/domain/project/service/ProjectService.java
@@ -245,8 +245,8 @@ public class ProjectService {
     }
 
     @Transactional(readOnly = true)
-    public List<SummaryProjectDto> getProjectSummaryByName(String projectName) {
-        List<Project> projects = projectRepository.findByName(projectName);
+    public List<SummaryProjectDto> getProjectSummaryByName(String email, String projectName) {
+        List<Project> projects = projectRepository.findByProjectNameAndUserEmail(projectName, email);
         return projects.stream().map(this::convertToSummaryDto).collect(Collectors.toList());
     }
     @Transactional(readOnly = true)


### PR DESCRIPTION
1. /api/v1/summary/by-name (프로젝트 연동하기에서 조회) : 설문을 진행했던 동일 이메일로 회원가입을 하지 않아 자동 연동이 안된 케이스라서 “로그인한 사용자 이름 + 프로젝트 명으로 검색한 결과”가 맞을까요?? 클라이언트에서는 프로젝트 명만 보내도 된다 생각하는데, 백엔드에서 로그인한 사용자 이름도 조회 조건에 넣었는지 궁금합니다
2. /api/v1/projects/{projectId} (프로젝트 수정) : 프로젝트 산출물 링크 공개/비공개 여부 request body 추가 필요

3. /api/v1/projects/summary/by-member-and-filters (프로젝트 이름,팀원명, 필터 조건으로 프로젝트 검색) : 이 부분은 검색 api를 염두에 두고 정리했던건데 XX님 담당이라고 알고있고, XX님도 api를 만들어주신걸로 압니다..  없어도 되는 api로 생각됩니다. 백엔드에서 남겨둬도 되긴 하구요..! 클라이언트에서는 호출하지 않는 api로 생각됩니다
4. /api/v1/projects/me-involved-projects/{projectId}, /api/v1/projects/summary/detail/{projectId} : 프로젝트 산출물 링크 공개/비공개 여부 조회 추가 필요
6. 프로젝트 연동하기에서 프로젝트 선택하여 연동진행하는 api는 아직인거죠?! 검색 결과를 클릭하여 ‘연동하기’ 버튼을 누르면 사용자를 선택하라는 라디오 버튼이 뜨는 흐름이었던 것 같습니다. XX님이 정리해주시기로 했던 것 같구요 @XXX  이부분은 글로 정리되었을까요??

dev comp