### PR TITLE
refactor : optimize getMeInvolvedProjects API select query #134

### DIFF
--- a/src/main/java/com/prismworks/prism/domain/peerreview/repository/PeerReviewTotalResultRepository.java
+++ b/src/main/java/com/prismworks/prism/domain/peerreview/repository/PeerReviewTotalResultRepository.java
@@ -1,8 +1,8 @@
 package com.prismworks.prism.domain.peerreview.repository;
 
-import com.prismworks.prism.domain.peerreview.model.PeerReviewResult;
 import com.prismworks.prism.domain.peerreview.model.PeerReviewTotalResult;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -21,4 +21,7 @@ public interface PeerReviewTotalResultRepository extends JpaRepository<PeerRevie
 
     PeerReviewTotalResult findByProjectIdAndEmailAndPrismType(int projectId, String email, String prismType);
     PeerReviewTotalResult findByProjectIdAndUserIdAndPrismType(int projectId, String userId, String prismType);
+
+    @Query("SELECT pr FROM PeerReviewTotalResult pr WHERE pr.projectId IN :projectIds AND pr.email = :email AND pr.prismType = :prismType")
+    List<PeerReviewTotalResult> findPeerReviewResultsByProjectIdsAndEmail(List<Integer> projectIds, String email, String prismType);
 }

--- a/src/main/java/com/prismworks/prism/domain/project/Repository/ProjectRepository.java
+++ b/src/main/java/com/prismworks/prism/domain/project/Repository/ProjectRepository.java
@@ -29,6 +29,14 @@ public interface ProjectRepository extends JpaRepository<Project, Integer>, Proj
     @Query("SELECT p FROM Project p WHERE p.createdBy = :email")
     List<Project> findByOwnerEmail(String email);
 
+    @Query("SELECT DISTINCT p FROM Project p " +
+        "LEFT JOIN FETCH p.categories pcj " +
+        "LEFT JOIN FETCH pcj.category c " +
+        "LEFT JOIN FETCH p.members puj " +
+        "LEFT JOIN FETCH puj.user u " +
+        "WHERE p.createdBy = :email")
+    List<Project> findProjectsWithCategoriesAndMembersByRegister(String email);
+
     Optional<Project> findByProjectIdAndCreatedBy(Integer projectId, String createdBy);
 
     @Query("SELECT p.anonyVisibility FROM ProjectUserJoin p WHERE p.email = :myEmail AND p.project.projectId = :projectId")

--- a/src/main/java/com/prismworks/prism/domain/project/Repository/ProjectRepository.java
+++ b/src/main/java/com/prismworks/prism/domain/project/Repository/ProjectRepository.java
@@ -26,8 +26,12 @@ public interface ProjectRepository extends JpaRepository<Project, Integer>, Proj
     @Query("SELECT p FROM Project p JOIN p.members m WHERE m.email = :email")
     List<Project> findByMemberEmail(String email);
 
-    @Query("SELECT p FROM Project p JOIN p.members m WHERE m.user.userId = :userId")
-    List<Project> findByMemberUserId(String userId);
+    @Query("SELECT DISTINCT p FROM Project p " +
+        "LEFT JOIN p.categories c " +
+        "LEFT JOIN c.category " +
+        "LEFT JOIN p.members m " +
+        "WHERE m.user.userId = :userId")
+    Page<Project> findByMemberUserId(String userId, Pageable pageable);
 
     @Query("SELECT p FROM Project p WHERE p.createdBy = :email")
     List<Project> findByOwnerEmail(String email);

--- a/src/main/java/com/prismworks/prism/domain/project/Repository/ProjectRepository.java
+++ b/src/main/java/com/prismworks/prism/domain/project/Repository/ProjectRepository.java
@@ -37,4 +37,11 @@ public interface ProjectRepository extends JpaRepository<Project, Integer>, Proj
     @Query("SELECT p FROM ProjectUserJoin p WHERE p.email = :myEmail AND p.project.projectId = :projectId")
     ProjectUserJoin findByMyEmailAndProjectId(Integer projectId,String myEmail);
 
+    @Query("SELECT DISTINCT p FROM Project p " +
+        "LEFT JOIN FETCH p.categories c " +
+        "LEFT JOIN FETCH c.category " +
+        "LEFT JOIN FETCH p.members m " +
+        "WHERE m.email = :email")
+    List<Project> findProjectsWithCategoriesAndMembersByEmail(String email);
+
 }

--- a/src/main/java/com/prismworks/prism/domain/project/Repository/ProjectRepository.java
+++ b/src/main/java/com/prismworks/prism/domain/project/Repository/ProjectRepository.java
@@ -3,6 +3,9 @@ package com.prismworks.prism.domain.project.Repository;
 import com.prismworks.prism.domain.project.Repository.custom.ProjectCustomRepository;
 import com.prismworks.prism.domain.project.model.Project;
 import com.prismworks.prism.domain.project.model.ProjectUserJoin;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -30,12 +33,12 @@ public interface ProjectRepository extends JpaRepository<Project, Integer>, Proj
     List<Project> findByOwnerEmail(String email);
 
     @Query("SELECT DISTINCT p FROM Project p " +
-        "LEFT JOIN FETCH p.categories pcj " +
-        "LEFT JOIN FETCH pcj.category c " +
-        "LEFT JOIN FETCH p.members puj " +
-        "LEFT JOIN FETCH puj.user u " +
+        "LEFT JOIN p.categories pcj " +
+        "LEFT JOIN pcj.category c " +
+        "LEFT JOIN p.members puj " +
+        "LEFT JOIN puj.user u " +
         "WHERE p.createdBy = :email")
-    List<Project> findProjectsWithCategoriesAndMembersByRegister(String email);
+    Page<Project> findProjectsWithCategoriesAndMembersByRegister(String email, Pageable pageable);
 
     Optional<Project> findByProjectIdAndCreatedBy(Integer projectId, String createdBy);
 
@@ -46,10 +49,10 @@ public interface ProjectRepository extends JpaRepository<Project, Integer>, Proj
     ProjectUserJoin findByMyEmailAndProjectId(Integer projectId,String myEmail);
 
     @Query("SELECT DISTINCT p FROM Project p " +
-        "LEFT JOIN FETCH p.categories c " +
-        "LEFT JOIN FETCH c.category " +
-        "LEFT JOIN FETCH p.members m " +
+        "LEFT JOIN p.categories c " +
+        "LEFT JOIN c.category " +
+        "LEFT JOIN p.members m " +
         "WHERE m.email = :email")
-    List<Project> findProjectsWithCategoriesAndMembersByEmail(String email);
+    Page<Project> findProjectsWithCategoriesAndMembersByEmail(String email, Pageable pageable);
 
 }

--- a/src/main/java/com/prismworks/prism/domain/project/Repository/ProjectUserJoinRepository.java
+++ b/src/main/java/com/prismworks/prism/domain/project/Repository/ProjectUserJoinRepository.java
@@ -1,5 +1,8 @@
 package com.prismworks.prism.domain.project.Repository;
 
+import java.util.List;
+import java.util.Map;
+
 import com.prismworks.prism.domain.project.model.ProjectUserJoin;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,4 +13,9 @@ public interface ProjectUserJoinRepository extends JpaRepository<ProjectUserJoin
 
     @Query("SELECT count(p) FROM ProjectUserJoin p WHERE p.project.projectId = :projectId AND p.peerReviewDone = true")
     int getSurveyParticipant(int projectId);
+
+    @Query("SELECT p.project.projectId, COUNT(p) FROM ProjectUserJoin p " +
+        "WHERE p.project.projectId IN :projectIds AND p.peerReviewDone = true " +
+        "GROUP BY p.project.projectId")
+    Map<Integer, Integer> findSurveyParticipantsByProjectIds(List<Integer> projectIds);
 }

--- a/src/main/java/com/prismworks/prism/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/prismworks/prism/domain/project/controller/ProjectController.java
@@ -64,9 +64,13 @@ public class ProjectController {
     }
 
     @GetMapping("/me-involved-projects")
-    public ApiSuccessResponse getMeInvolvedProjects(@CurrentUser UserContext userContext) {
+    public ApiSuccessResponse getMeInvolvedProjects(
+        @CurrentUser UserContext userContext,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
         String myEmail = userContext.getEmail();
-        List<SummaryProjectDto> myProjects = projectService.getMeInvolvedProjects(myEmail);
+        List<SummaryProjectDto> myProjects = projectService.getMeInvolvedProjects(myEmail, page, size);
         return new ApiSuccessResponse(HttpStatus.OK.value(), myProjects);
     }
 
@@ -78,9 +82,13 @@ public class ProjectController {
     }
 
     @GetMapping("/me-registered-projects")
-    public ApiSuccessResponse getMyRegisteredProjects(@CurrentUser UserContext userContext) {
+    public ApiSuccessResponse getMyRegisteredProjects(
+        @CurrentUser UserContext userContext,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
         String myEmail = userContext.getEmail();
-        List<SummaryProjectDto> myRegisteredProjects = projectService.getMeRegisteredProjects(myEmail);
+        List<SummaryProjectDto> myRegisteredProjects = projectService.getMeRegisteredProjects(myEmail, page, size);
         return new ApiSuccessResponse(HttpStatus.OK.value(), myRegisteredProjects);
     }
 

--- a/src/main/java/com/prismworks/prism/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/prismworks/prism/domain/project/controller/ProjectController.java
@@ -76,8 +76,12 @@ public class ProjectController {
 
     //굳이 내가 아니라 다른사람 프로필 검색할 때 프로젝트 리스트 뿌려주는 api
     @GetMapping("/who-involved-projects")
-    public ApiSuccessResponse getWhoInvolvedProjects(@RequestParam("userId") String userId) {
-        List<SummaryProjectDto> whosProjects = projectService.getWhoInvolvedProjects(userId);
+    public ApiSuccessResponse getWhoInvolvedProjects(
+        @RequestParam("userId") String userId,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
+        List<SummaryProjectDto> whosProjects = projectService.getWhoInvolvedProjects(userId, page, size);
         return new ApiSuccessResponse(HttpStatus.OK.value(), whosProjects);
     }
 

--- a/src/main/java/com/prismworks/prism/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/prismworks/prism/domain/project/controller/ProjectController.java
@@ -7,6 +7,7 @@ import com.prismworks.prism.domain.project.dto.*;
 import com.prismworks.prism.domain.project.service.ProjectService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -70,7 +71,7 @@ public class ProjectController {
         @RequestParam(defaultValue = "10") int size
     ) {
         String myEmail = userContext.getEmail();
-        List<SummaryProjectDto> myProjects = projectService.getMeInvolvedProjects(myEmail, page, size);
+        Page<SummaryProjectDto> myProjects = projectService.getMeInvolvedProjects(myEmail, page, size);
         return new ApiSuccessResponse(HttpStatus.OK.value(), myProjects);
     }
 
@@ -81,7 +82,7 @@ public class ProjectController {
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "10") int size
     ) {
-        List<SummaryProjectDto> whosProjects = projectService.getWhoInvolvedProjects(userId, page, size);
+        Page<SummaryProjectDto> whosProjects = projectService.getWhoInvolvedProjects(userId, page, size);
         return new ApiSuccessResponse(HttpStatus.OK.value(), whosProjects);
     }
 
@@ -92,7 +93,7 @@ public class ProjectController {
         @RequestParam(defaultValue = "10") int size
     ) {
         String myEmail = userContext.getEmail();
-        List<SummaryProjectDto> myRegisteredProjects = projectService.getMeRegisteredProjects(myEmail, page, size);
+        Page<SummaryProjectDto> myRegisteredProjects = projectService.getMeRegisteredProjects(myEmail, page, size);
         return new ApiSuccessResponse(HttpStatus.OK.value(), myRegisteredProjects);
     }
 

--- a/src/main/java/com/prismworks/prism/domain/project/model/Project.java
+++ b/src/main/java/com/prismworks/prism/domain/project/model/Project.java
@@ -6,6 +6,8 @@ import lombok.Data;
 
 import java.util.*;
 
+import org.hibernate.annotations.BatchSize;
+
 @Data
 @Entity
 @Table(name = "project")
@@ -32,6 +34,7 @@ public class Project {
     private List<String> hashTags;
 
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = 100)
     @JsonManagedReference
     private Set<ProjectCategoryJoin> categories = new HashSet<>();
 
@@ -47,6 +50,7 @@ public class Project {
     private Date endDate;
 
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 100)
     private List<ProjectUserJoin> members = new ArrayList<>();
     /*
     @Column(nullable = true)

--- a/src/main/java/com/prismworks/prism/domain/project/service/ProjectService.java
+++ b/src/main/java/com/prismworks/prism/domain/project/service/ProjectService.java
@@ -19,6 +19,9 @@ import com.prismworks.prism.domain.user.model.Users;
 import com.prismworks.prism.domain.user.repository.UserRepository;
 import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -294,8 +297,9 @@ public class ProjectService {
         return projects.stream().map(this::convertToSummaryDto).collect(Collectors.toList());
     }
     @Transactional(readOnly = true)
-    public List<SummaryProjectDto> getMeInvolvedProjects(String myEmail) {
-        return getProjectsSummary(myEmail, projectRepository.findProjectsWithCategoriesAndMembersByEmail(myEmail));
+    public List<SummaryProjectDto> getMeInvolvedProjects(String myEmail, int page, int size) {
+        Page<Project> projectPage = projectRepository.findProjectsWithCategoriesAndMembersByEmail(myEmail, PageRequest.of(page, size));
+        return getProjectsSummary(myEmail, projectPage.getContent());
     }
     @Transactional(readOnly = true)
     public List<SummaryProjectDto> getWhoInvolvedProjects(String userId) {
@@ -336,8 +340,9 @@ public class ProjectService {
     }
 
     @Transactional(readOnly = true)
-    public List<SummaryProjectDto> getMeRegisteredProjects(String myEmail) {
-        return getProjectsSummary(myEmail, projectRepository.findProjectsWithCategoriesAndMembersByRegister(myEmail));
+    public List<SummaryProjectDto> getMeRegisteredProjects(String myEmail, int page, int size) {
+        Page<Project> projectPage = projectRepository.findProjectsWithCategoriesAndMembersByRegister(myEmail, PageRequest.of(page, size));
+        return getProjectsSummary(myEmail, projectPage.getContent());
     }
 
     private List<SummaryProjectDto> getProjectsSummary(String myEmail, List<Project> projects) {


### PR DESCRIPTION
## 수정내용
- Project 관련 API 에서 OnetoMany 형식의 연관관계에 따른 JPQL 수정 및 추가
    - findPeerReviewResultsByProjectIdsAndEmail 쿼리 추가
    - findProjectsWithCategoriesAndMembersByRegister 쿼리 추가
    - findProjectsWithCategoriesAndMembersByEmail 쿼리  추가
    - findSurveyParticipantsByProjectIds 쿼리 추가
- 코드 리팩토링
    - getProjectsSummary 메서드를 선언하 Project의 세부값 세팅 방법을 통일시킴

## N+1 이슈 발생 관련 공유
### 1. 발생 원인
- ProjectDto와 ProjectDetailDto 에 anonyVisibility  관련된 필드가 존재하지 않음
- 현재는 boolean <ins>findByAnonyVisibility</ins>(Integer projectId,String myEmail) 메서드만을 이용해서 anony_visibility 가져옴
- 각 Project 마다 anony_visibility을 조회하기 위해 <ins>findByAnonyVisibility</ins> 메서드를 한번씩 조회하기 때문에 N+1 발생

### 2. 생각해본 해결방안
- ProjectDto에 anony_visibility 필드를 추가
    - ProjectDto에 대한 정합성이 깨짐
- ProjectDetailDto에 anony_visibility 필드를 추가
    - ProjectDetailDto에는 projectId가 없어 로직 증가